### PR TITLE
Don't crash when unable to download a revision.

### DIFF
--- a/SonarTfsAnnotate/HistoryProvider.cs
+++ b/SonarTfsAnnotate/HistoryProvider.cs
@@ -6,6 +6,7 @@
  */
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using Microsoft.TeamFoundation.VersionControl.Client;
@@ -44,25 +45,34 @@ namespace SonarSource.TfsAnnotate
 
         public bool Next()
         {
-            if (current - 1 >= 0)
+            while (true)
             {
-                Dispose(current - 1);
+                if (current - 1 >= 0)
+                {
+                    Dispose(current - 1);
+                }
+
+                current++;
+                if (current >= changesets.Count)
+                {
+                    return false;
+                }
+
+                if (current + PREFETCH_SIZE < changesets.Count)
+                {
+                    Prefetch(current + PREFETCH_SIZE);
+                }
+
+                manualResetEvents[current].WaitOne();
+
+                if (!File.Exists(filenames[current]))
+                {
+                    // The download was not successful. Move on to the next file.
+                    continue;
+                }
+
+                return true;
             }
-
-            current++;
-            if (current >= changesets.Count)
-            {
-                return false;
-            }
-
-            if (current + PREFETCH_SIZE < changesets.Count)
-            {
-                Prefetch(current + PREFETCH_SIZE);
-            }
-
-            manualResetEvents[current].WaitOne();
-
-            return true;
         }
 
         public Changeset Changeset()
@@ -133,8 +143,18 @@ namespace SonarSource.TfsAnnotate
 
             public void Prefetch(object o)
             {
-                item.DownloadFile(filename);
-                manualResetEvent.Set();
+                try
+                {
+                    item.DownloadFile(filename);
+                }
+                catch (Exception e)
+                {
+                    Trace.WriteLine(e.Message);
+                }
+                finally
+                {
+                    manualResetEvent.Set();
+                }
             }
         }
     }


### PR DESCRIPTION
We have an item in history that we are unable to download just one historical revision. It doesn't work from visual studio or the annotation program. In the annotation program, an exception is thrown in prefetch causing the annotation program to crash. While we are trying to engage Microsoft it's pretty low priority except it causes the annotation process to crash which in turn causes the entire sonar build to fail. This isn't desirable behavior from my perspective. This patch will allow the annotation to continue in the case of a download failure. Since there is no error reporting mechanism I've chosen to just trace the output. Perhaps using Console.Error should be considered in the future? 